### PR TITLE
The Devops handbook 

### DIFF
--- a/books/The DevOps Handbook.yml
+++ b/books/The DevOps Handbook.yml
@@ -1,0 +1,6 @@
+---
+book:
+  kudo: YannickteKulve
+  isbn: '9781942788003'
+  tags:
+    - agile


### PR DESCRIPTION
The Devops handbook is the follow up of the phoenix project. It's a practical guide on devops culture. 